### PR TITLE
Sparing CPU consumption

### DIFF
--- a/dist/mixer.js
+++ b/dist/mixer.js
@@ -48,8 +48,8 @@ class Mixer extends stream_1.Readable {
             this.push(mixedBuffer);
         }
         else if (this.needReadable) {
-            clearImmediate(this._timer);
-            this._timer = setImmediate(this._read.bind(this));
+            clearTimeout(this._timer);
+            this._timer = setTimeout(this._read.bind(this), 500 / this.args.sampleRate);
         }
         this.clearBuffers();
     }

--- a/src/mixer.ts
+++ b/src/mixer.ts
@@ -79,8 +79,8 @@ export class Mixer extends Readable {
 
             this.push(mixedBuffer);
         } else if(this.needReadable) {
-            clearImmediate(this._timer)
-            this._timer = setImmediate(this._read.bind(this));
+            clearTimeout(this._timer)
+            this._timer = setTimeout(this._read.bind(this), 500/this.args.sampleRate);
         }
 
         this.clearBuffers();


### PR DESCRIPTION
Currently when there is no data, the mixer do an active polling at high frequency (tick's frequency) that is not really mandatory and use the CPU its max (100% CPU usage). I slowed it down at half of the sampling period, this is enough to get data on time.

I also noticed that the sampleRate is actually useless: it is not taken in account and not used to perform anything else... (to discuss in another issue)